### PR TITLE
Change the implementation to handle rerendered elements correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-dist/
 node_modules/

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,19 @@
+declare module 'react-use-sync-scroll' {
+  import { RefObject } from 'react'
+
+  export interface SyncScrollOptions {
+    /**
+     * @default false
+     */
+    horizontal?: boolean
+
+    /**
+     * @default false
+     */
+    vertical?: boolean
+  }
+
+  function useSyncScroll(refs: RefObject<any>, options: SyncScrollOptions): void
+
+  export default useSyncScroll
+}

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1,0 +1,59 @@
+import React, { useCallback } from 'react';
+
+function syncScroll(target, others, TopLeft, WidthHeight) {
+  const percentage = target[`scroll${TopLeft}`] / (target[`scroll${WidthHeight}`] - target[`offset${WidthHeight}`]); // eslint-disable-next-line no-undef
+
+  window.requestAnimationFrame(() => {
+    others.forEach(el => {
+      el[`scroll${TopLeft}`] = Math.round(percentage * (el[`scroll${WidthHeight}`] - el[`offset${WidthHeight}`]));
+    });
+  });
+}
+
+function syncVerticalScroll(target, others) {
+  syncScroll(target, others, 'Top', 'Height');
+}
+
+function syncHorizontalScroll(target, others) {
+  syncScroll(target, others, 'Left', 'Width');
+}
+
+function useSyncScroll({
+  vertical,
+  horizontal
+}) {
+  const elementsRef = React.useRef([]);
+  const locksRef = React.useRef(0);
+  const refCallback = useCallback(element => {
+    const currentElements = elementsRef.current;
+
+    if (element) {
+      // eslint-disable-next-line
+      element.addEventListener('scroll', handleScroll);
+      currentElements.push(element);
+    } else {
+      // eslint-disable-next-line
+      currentElements.forEach(el => el.removeEventListener('scroll', handleScroll));
+      currentElements.splice(0, currentElements.length);
+    }
+
+    function handleScroll({
+      target
+    }) {
+      if (locksRef.current > 0) {
+        locksRef.current -= 1; // Release lock by 1
+
+        return;
+      }
+
+      locksRef.current = elementsRef.current.length - 1; // Acquire lock
+
+      const others = elementsRef.current.filter(ref => ref !== target);
+      if (vertical) syncVerticalScroll(target, others);
+      if (horizontal) syncHorizontalScroll(target, others);
+    }
+  }, [horizontal, vertical]);
+  return refCallback;
+}
+
+export default useSyncScroll;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,67 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('react')) :
+  typeof define === 'function' && define.amd ? define(['react'], factory) :
+  (global = global || self, global.useSyncScroll = factory(global.React));
+}(this, (function (React) { 'use strict';
+
+  var React__default = 'default' in React ? React['default'] : React;
+
+  function syncScroll(target, others, TopLeft, WidthHeight) {
+    const percentage = target[`scroll${TopLeft}`] / (target[`scroll${WidthHeight}`] - target[`offset${WidthHeight}`]); // eslint-disable-next-line no-undef
+
+    window.requestAnimationFrame(() => {
+      others.forEach(el => {
+        el[`scroll${TopLeft}`] = Math.round(percentage * (el[`scroll${WidthHeight}`] - el[`offset${WidthHeight}`]));
+      });
+    });
+  }
+
+  function syncVerticalScroll(target, others) {
+    syncScroll(target, others, 'Top', 'Height');
+  }
+
+  function syncHorizontalScroll(target, others) {
+    syncScroll(target, others, 'Left', 'Width');
+  }
+
+  function useSyncScroll({
+    vertical,
+    horizontal
+  }) {
+    const elementsRef = React__default.useRef([]);
+    const locksRef = React__default.useRef(0);
+    const refCallback = React.useCallback(element => {
+      const currentElements = elementsRef.current;
+
+      if (element) {
+        // eslint-disable-next-line
+        element.addEventListener('scroll', handleScroll);
+        currentElements.push(element);
+      } else {
+        // eslint-disable-next-line
+        currentElements.forEach(el => el.removeEventListener('scroll', handleScroll));
+        currentElements.splice(0, currentElements.length);
+      }
+
+      function handleScroll({
+        target
+      }) {
+        if (locksRef.current > 0) {
+          locksRef.current -= 1; // Release lock by 1
+
+          return;
+        }
+
+        locksRef.current = elementsRef.current.length - 1; // Acquire lock
+
+        const others = elementsRef.current.filter(ref => ref !== target);
+        if (vertical) syncVerticalScroll(target, others);
+        if (horizontal) syncHorizontalScroll(target, others);
+      }
+    }, [horizontal, vertical]);
+    return refCallback;
+  }
+
+  return useSyncScroll;
+
+})));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
I've fixed an issue where scroll synchronization didn't work after the elements being synchronized had rerendered.
The problem was related to how React refs work with `useEffect` hook. There are more details and proposed solution which I've used in [this article](https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780).

## Related issues
<!-- Reference one issue per list item from Clubhouse -->

- Fixes: https://app.clubhouse.io/tymeshift/story/5832/fix-an-issue-with-scroll-synchronization-library

## Instructions for QA
<!--- List here any specific instructions or tips for QA to test this. -->
Not necessary.
